### PR TITLE
Check output connections in process on event triggers

### DIFF
--- a/src/modules/poly-same-diff.cpp
+++ b/src/modules/poly-same-diff.cpp
@@ -118,15 +118,15 @@ void PolySameDiffModule::process(const ProcessArgs& args) {
 }
 
 void PolySameDiffModule::onAdd(const AddEvent& e) {
-	updateConnectionStatus();
+	m_clockDivider.setDivision(0);
 }
 
 void PolySameDiffModule::onPortChange(const PortChangeEvent& event) {
-	updateConnectionStatus();
+	m_clockDivider.setDivision(0);
 }
 
 void PolySameDiffModule::onUnBypass(const UnBypassEvent& e) {
-	updateConnectionStatus();
+	m_clockDivider.setDivision(0);
 }
 
 bool PolySameDiffModule::getOutputDuplicates() {
@@ -139,7 +139,7 @@ void PolySameDiffModule::setOutputDuplicates(bool outputDuplicates) {
 
 void PolySameDiffModule::setModuleWidget(ModuleWidget *moduleWidget) {
 	m_moduleWidget = moduleWidget;
-	updateConnectionStatus();
+	m_clockDivider.setDivision(0);
 }
 
 void PolySameDiffModule::updateConnectionStatus() {


### PR DESCRIPTION
The event triggers (e.g. cable disconnects) are triggered during Rack shutdown, at which point retrieving the top cable for the output ports may no longer be possible due to the engine state (noticed on Rack v2.5.2, not on Rack v2.6.0 development build). Instead of re-checking the output connections immediately in the event trigger, update the clock trigger object to cause the re-check to happen in the next process() invocation.