### PR TITLE
Remove output detection due to issues during VCV Rack shutdown

### DIFF
--- a/include/modules/poly-same-diff.hpp
+++ b/include/modules/poly-same-diff.hpp
@@ -31,27 +31,13 @@ struct PolySameDiffModule : NTModule {
 
 	void process(const ProcessArgs& args) override;
 
-	void onAdd(const AddEvent& e) override;
-	void onPortChange(const PortChangeEvent& event) override;
-	void onUnBypass(const UnBypassEvent& e) override;
-
 	bool getOutputDuplicates();
 	void setOutputDuplicates(bool outputDuplicates);
-
-	void setModuleWidget(ModuleWidget *moduleWidget);
 
 	private:
 		bool m_outputDuplicates = false;
 		float m_floatBuffA[16];
 		float m_floatBuffB[16];
-
-		ModuleWidget *m_moduleWidget = nullptr;
-		dsp::ClockDivider m_clockDivider;
-		bool m_aConnected = true;
-		bool m_bConnected = true;
-		bool m_abConnected = true;
-
-		void updateConnectionStatus();
 	};
 
 struct PolySameDiffWidget : NTModuleWidget {


### PR DESCRIPTION
Detection of active cables on output ports results in accessing deleted memory during VCV Rack shutdown when done from within the process() method (especially at high sample rates). No reliable workaround found to detect this scenario, so removing the output connection detection mechanism.