### PR TITLE
Add missing cstdint include

### DIFF
--- a/include/core/timeseq-script.hpp
+++ b/include/core/timeseq-script.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace timeseq {
 


### PR DESCRIPTION
gcc 15.1.1 complained when compiling the latest v2.0.3:
```
In file included from ./include/core/timeseq-json.hpp:3,
                 from ./include/core/timeseq-core.hpp:3,
                 from src/core/timeseq-core.cpp:1:
./include/core/timeseq-script.hpp:172:25: error: ‘uint64_t’ was not declared in this scope
  172 |         std::unique_ptr<uint64_t> samples;
      |                         ^~~~~~~~
./include/core/timeseq-script.hpp:6:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    5 | #include <vector>
  +++ |+#include <cstdint>
    6 | 
```
This patch fixes it.